### PR TITLE
Fix InvokeAsync invocations to use return type template parameter

### DIFF
--- a/src/SigSpec.CodeGeneration.CSharp/Templates/Hub.liquid
+++ b/src/SigSpec.CodeGeneration.CSharp/Templates/Hub.liquid
@@ -50,7 +50,7 @@
 {%     elsif operation.HasReturnType -%}
         public async Task<{{ operation.ReturnType.Type }}> {{ operation.Name }}({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.Name }}, {% endfor %}CancellationToken token = default(CancellationToken))
         {
-            return await _connection.InvokeAsync("{{ operation.Name }}"{% for parameter in operation.Parameters %}, {{ parameter.Name }}{% endfor %}, token);
+            return await _connection.InvokeAsync<{{ operation.ReturnType.Type }}>("{{ operation.Name }}"{% for parameter in operation.Parameters %}, {{ parameter.Name }}{% endfor %}, token);
         }
 
 {%     else -%}


### PR DESCRIPTION
The InvokeAsync methods in the C# liquid template is modified to that the type template parameter is used correctly. This PR fixes #51.