### PR TITLE
.NET 8 Compatibility

### DIFF
--- a/src/HelloSignalR/HelloSignalR.csproj
+++ b/src/HelloSignalR/HelloSignalR.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="wwwroot\" />

--- a/src/SigSpec.AspNetCore/SigSpec.AspNetCore.csproj
+++ b/src/SigSpec.AspNetCore/SigSpec.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <Owners>Rico Suter</Owners>

--- a/src/SigSpec.CodeGeneration.CSharp/SigSpec.CodeGeneration.CSharp.csproj
+++ b/src/SigSpec.CodeGeneration.CSharp/SigSpec.CodeGeneration.CSharp.csproj
@@ -22,8 +22,8 @@
     <EmbeddedResource Include="Templates\Hub.liquid" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="njsonschema.codegeneration" Version="10.7.1" />
-    <PackageReference Include="njsonschema.codegeneration.csharp" Version="10.7.1" />
+    <PackageReference Include="njsonschema.codegeneration" Version="11.0.0" />
+    <PackageReference Include="njsonschema.codegeneration.csharp" Version="11.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SigSpec.CodeGeneration\SigSpec.CodeGeneration.csproj" />

--- a/src/SigSpec.CodeGeneration.TypeScript/SigSpec.CodeGeneration.TypeScript.csproj
+++ b/src/SigSpec.CodeGeneration.TypeScript/SigSpec.CodeGeneration.TypeScript.csproj
@@ -22,8 +22,8 @@
     <EmbeddedResource Include="Templates\Hub.liquid" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.7.1" />
-    <PackageReference Include="NJsonSchema.CodeGeneration.TypeScript" Version="10.7.1" />
+    <PackageReference Include="NJsonSchema.CodeGeneration" Version="11.0.0" />
+    <PackageReference Include="NJsonSchema.CodeGeneration.TypeScript" Version="11.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />

--- a/src/SigSpec.CodeGeneration/SigSpec.CodeGeneration.csproj
+++ b/src/SigSpec.CodeGeneration/SigSpec.CodeGeneration.csproj
@@ -14,7 +14,7 @@
     <PackageTags>SignalR Specification CodeGeneration</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.7.1" />
+    <PackageReference Include="NJsonSchema.CodeGeneration" Version="11.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />

--- a/src/SigSpec.Console/SigSpec.Console.csproj
+++ b/src/SigSpec.Console/SigSpec.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>dotnet-sigspec</AssemblyName>
     <RootNamespace>SigSpec</RootNamespace>
   </PropertyGroup>

--- a/src/SigSpec.Core/SigSpec.Core.csproj
+++ b/src/SigSpec.Core/SigSpec.Core.csproj
@@ -14,8 +14,9 @@
     <PackageTags>SignalR Specification CodeGeneration</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.7.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="NJsonSchema" Version="11.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.0" />
   </ItemGroup>
 </Project>

--- a/src/SigSpec.Core/SigSpecDocument.cs
+++ b/src/SigSpec.Core/SigSpecDocument.cs
@@ -2,9 +2,9 @@
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using NJsonSchema;
-using NJsonSchema.Converters;
 using System;
 using System.Collections.Generic;
+using NJsonSchema.NewtonsoftJson.Converters;
 
 namespace SigSpec.Core
 {

--- a/src/SigSpec.Core/SigSpecGeneratorSettings.cs
+++ b/src/SigSpec.Core/SigSpecGeneratorSettings.cs
@@ -1,10 +1,10 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 namespace SigSpec.Core
 {
-    public class SigSpecGeneratorSettings : JsonSchemaGeneratorSettings
+    public class SigSpecGeneratorSettings : NewtonsoftJsonSchemaGeneratorSettings
     {
         public SigSpecGeneratorSettings()
         {


### PR DESCRIPTION
- Updated `NJsonSchema` packages to versions that support .net8
  - Resolve build errors
-  Bump example application versions to remove build warnings